### PR TITLE
Change (req,res) to (request,response) in schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A single request and response pair is represented as shown in the below example:
 
 ```json
 {
-  "req": {
+  "request": {
     "protocol": "http",
     "method": "get",
     "headers": {
@@ -26,7 +26,7 @@ A single request and response pair is represented as shown in the below example:
     "pathname": "/user/repos",
     "host": "example.com"
   },
-  "res": {
+  "response": {
     "statusCode": 200,
     "body": "...",
     "headers": {

--- a/http-types-schema.json
+++ b/http-types-schema.json
@@ -4,9 +4,9 @@
   "type": "object",
   "title": "HttpExchange",
   "description": "A HTTP request and response pair.",
-  "required": [ "req" ],
+  "required": [ "request" ],
   "properties": {
-    "req": {
+    "request": {
       "type": "object",
       "required": ["protocol", "method", "headers", "path", "host"],
       "properties": {
@@ -41,7 +41,7 @@
         }
       }
     },
-    "res": {
+    "response": {
       "type": "object",
       "required": [],
       "properties": {

--- a/simple-sample.json
+++ b/simple-sample.json
@@ -1,5 +1,5 @@
 {
-  "req": {
+  "request": {
     "protocol": "http",
     "method": "get",
     "headers": {
@@ -10,7 +10,7 @@
     "pathname": "/user/repos",
     "host": "example.com"
   },
-  "res": {
+  "response": {
     "statusCode": 200,
     "body": "...",
     "headers": {


### PR DESCRIPTION
I think using `{ "request": ..., "response": ... }` is nicer than `{ "req": ..., "res": ... }` in the JSON format. What do you think?

Note that this is for the JSON schema only. Language implementations could still use `req`/`res` fields/methods if that fits the convention of the language (but I don't think that applies to python), but still serialising to the common format with `request`/`response`. 

If we go for this I can make the follow up changes in https://github.com/Meeshkan/py-http-types/ and https://github.com/Meeshkan/meeshkan (is there anything in addition?).