### PR TITLE
Replace query, path, pathname and host properties with url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,12 @@ A single request and response pair is represented as shown in the below example:
 ```json
 {
   "req": {
-    "protocol": "http",
+    "url": "http://example.com/user/repos?param=value",
     "method": "get",
     "headers": {
       "accept": "*/*",
       "user-agent": "Mozilla/5.0 (pc-x86_64-linux-gnu) Siege/3.0.8"
-    },
-    "path": "/user/repos",
-    "pathname": "/user/repos",
-    "host": "example.com"
+    }
   },
   "res": {
     "statusCode": 200,

--- a/http-types-schema.json
+++ b/http-types-schema.json
@@ -8,14 +8,14 @@
   "properties": {
     "req": {
       "type": "object",
-      "required": ["protocol", "method", "headers", "path", "host"],
+      "required": ["url", "method", "headers"],
       "properties": {
+        "url": {
+          "type": "string",
+          "pattern": "https?://"
+        },
         "body": {
           "type": "string"
-        },
-        "protocol": {
-          "type": "string",
-          "enum": ["http", "https"]
         },
         "method": {
           "type": "string"
@@ -24,20 +24,6 @@
           "type": "object",
           "required": [],
           "additionalProperties": { "type": "string" }
-        },
-        "query": {
-          "type": "object",
-          "required": [],
-          "additionalProperties": { "type": "string" }
-        },
-        "path": {
-          "type": "string"
-        },
-        "pathname": {
-          "type": "string"
-        },
-        "host": {
-          "type": "string"
         }
       }
     },

--- a/simple-sample.json
+++ b/simple-sample.json
@@ -1,14 +1,11 @@
 {
   "req": {
-    "protocol": "http",
+    "url": "http://example.com/user/repos?param1=value1&param2=value2",
     "method": "get",
     "headers": {
       "accept": "*/*",
       "user-agent": "Mozilla/5.0 (pc-x86_64-linux-gnu) Siege/3.0.8"
-    },
-    "path": "/user/repos",
-    "pathname": "/user/repos",
-    "host": "example.com"
+    }
   },
   "res": {
     "statusCode": 200,


### PR DESCRIPTION
Note that this change is for the JSON format only. Implementations in languages should still provide methods/fields like py-http-types does today for accessing properties separately like

- the HTTP method as an enum
- the path without the query
- the query parameters as a (multi)map data structure
- the host without port
- the port
- an instance of the URL class from the standard library, if the language has one

# Possible advantages with this change:
- Removes the duplication between path and pathname.
- Makes it easier to generate the format from scripts and programs.
- Makes it easier to convert to and from HAR format (which also uses a `url` property).
- Reduces the number of fields (less schema/less complexity for people).

# Possible disadvantages with this change:
- It's not as simple to e.g. query for a specific query parameter using say `jq`.

What do you think?

If we go for this I can make the follow up changes in https://github.com/Meeshkan/py-http-types/ and https://github.com/Meeshkan/meeshkan (is there anything in addition?). Note that this doesn't need to change the API (the fields) of py-http-types - the same fields can be present, changes can be handled in serialisation only. We could e.g. make things like the `query` field a lazy property, to avoid having to parse the query string if one is processing bigger amount of data.